### PR TITLE
#162164332 Add descriptive popup messages

### DIFF
--- a/src/actions/commentAction.js
+++ b/src/actions/commentAction.js
@@ -8,7 +8,6 @@ export const fetchAction = slug => (dispatch) => {
   fetch(`${baseUrl}/api/articles/${slug}/comments/`)
     .then(response => response.json())
     .then((data) => {
-      console.log(data);
       dispatch({
         type: GET_COMMENT,
         payload: data.comments,

--- a/src/actions/loginActions.jsx
+++ b/src/actions/loginActions.jsx
@@ -1,24 +1,23 @@
-import { Exception } from 'handlebars';
 import { LOGIN_SUCCESS, LOGIN_FAILURE } from './types';
 
 
 const baseurl = 'https://ah-backend-stark-staging.herokuapp.com';
 
-const loginSuccess = data => (dispatch) => {
+export const loginSuccess = data => (dispatch) => {
   dispatch({
     type: LOGIN_SUCCESS,
     payload: data,
   });
 };
 
-const loginFailure = data => (dispatch) => {
+export const loginFailure = data => (dispatch) => {
   dispatch({
     type: LOGIN_FAILURE,
     payload: data,
   });
 };
 
-const loginAction = userdata => dispatch => fetch(`${baseurl}/api/users/login/`, {
+export const loginAction = userdata => dispatch => fetch(`${baseurl}/api/users/login/`, {
   method: 'POST',
   headers: {
     'Content-type': 'application/json',
@@ -29,13 +28,12 @@ const loginAction = userdata => dispatch => fetch(`${baseurl}/api/users/login/`,
   .then((data) => {
     if (data.errors) {
       dispatch(loginFailure(data));
-      throw Exception;
+      return { success: false };
     }
     dispatch(loginSuccess(data));
     const token = data.user.token;
     localStorage.setItem('token', token);
     const username = data.user.username;
     localStorage.setItem('username', username);
+    return { success: true };
   });
-
-export default loginAction;

--- a/src/components/ArticleCard1.jsx
+++ b/src/components/ArticleCard1.jsx
@@ -33,7 +33,6 @@ export class ArticleCard extends Component {
             <div class="row">
             <div class="col-lg-12"> <button className="fa fa-edit btn-article" id="but1" aria-hidden="true" onClick={()=>{this.goUpdate(this.props.slug)}}/></div></div><br /><br />
           <div class="row"><div class="col-lg-12"><button type="button" id="deleteButton" className="fa fa-trash btn-article" onClick={()=>{this.props.deleteArticles(this.props.slug)}}/></div></div></div> :" "}</div>
-            {/* Icons bar goes here */}
       </div>
       </div>
     );

--- a/src/components/LoginModal.jsx
+++ b/src/components/LoginModal.jsx
@@ -16,9 +16,7 @@ class LoginModal extends Component {
           <div className="modal-dialog">
             <div className="modal-form">
             <LoginForm 
-            toggleModal={this.toggleModal}
-            email={"none"}
-            password={"none"} 
+            toggleModal={this.toggleModal} 
             />
             </div>
           </div>

--- a/src/components/ViewArticle.js
+++ b/src/components/ViewArticle.js
@@ -2,9 +2,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import renderHTML from 'react-render-html';
 import PropTypes from 'prop-types';
-import { ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
 import NavigationBar from './navigation/NavigationBar';
+import { toast } from 'react-toastify';
 import ArticleHeader from './ArticleHeader';
 import {
   singleArticle,
@@ -25,6 +24,20 @@ class Article extends Component {
     if (this.props.match.params.slug) {
       const slug = this.props.match.params.slug;
       this.props.singleArticle(slug);
+    }
+  }
+
+  componentWillReceiveProps() {
+    if (this.props.like === 'liked') {
+      toast.success("You have liked this article", {
+        position: toast.POSITION.TOP_CENTER,
+        hideProgressBar:true
+    });
+    } else if (this.props.like === 'disliked') {
+      toast.error("You have disliked this article", {
+        position: toast.POSITION.TOP_CENTER,
+        hideProgressBar:true
+    });
     }
   }
 
@@ -78,7 +91,6 @@ componentDidUpdate(prevProps){
               <div className="center">
                 <h5>{article.description}</h5>
               </div>
-              <ToastContainer />
               <center>
                 <img className="img-article" src={article.image} />
               </center>
@@ -155,6 +167,7 @@ Article.propTypes = {
 
 const mapStateToProps = state => ({
   article: state.articles.article,
+  like: state.articles.like
 });
 
 export default connect(

--- a/src/reducers/loginReducer.jsx
+++ b/src/reducers/loginReducer.jsx
@@ -4,7 +4,7 @@ import { LOGIN_SUCCESS, LOGIN_FAILURE } from '../actions/types';
 const initialState = {
   message: '',
   user: {},
-  status: "none",
+  status: "",
 };
 
 export default function (state = initialState, action) {
@@ -12,8 +12,8 @@ export default function (state = initialState, action) {
     case LOGIN_FAILURE:
       return {
         ...state,
-        message: action.payload.errors,
         status: "error",
+        message: action.payload.errors,
       };
 
     case LOGIN_SUCCESS:

--- a/src/tests/LoginAction.test.js
+++ b/src/tests/LoginAction.test.js
@@ -1,0 +1,74 @@
+import thunk from 'redux-thunk';
+import fetchMock from 'fetch-mock';
+import configureStore from 'redux-mock-store';
+import * as actions from '../actions/loginActions';
+
+ 
+const baseurl = 'https://ah-backend-stark-staging.herokuapp.com';
+const userdata = {
+  user: {
+    email: 'testuser@email.com',
+    password: 'Testuser1',
+  },
+};
+let store;
+ 
+ 
+describe('async login actions', () => {
+  const mockStore = configureStore([thunk]);
+ 
+  beforeEach(() => {
+    store = mockStore({
+      message: '',
+      user: {},
+      status: 'none',
+    });
+  });
+ 
+  afterEach(() => {
+    fetchMock.reset();
+    fetchMock.restore();
+  });
+ 
+  it('creates LOGIN_FAILURE when login is unsuccessful', () => {
+    const data = {
+      status: 404,
+      errors: {
+        error: ['A user with this email and password was not found.'],
+      },
+    };
+    fetchMock.post(`${baseurl}/api/users/login/`, data);
+    const expectedActions = [
+      {
+        type: 'LOGIN_FAILURE',
+        payload: data,
+      },
+    ];
+    return store.dispatch(actions.loginAction(userdata)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('creates LOGIN_SUCCESSFUL when login is successful', () => {
+    const data = {
+      status: 200,
+      user: {
+        token: 'user-token',
+        username: 'testuser',
+        email: 'testuser@email.com',
+      },
+    };
+ 
+    fetchMock.post(`${baseurl}/api/users/login/`, data);
+    const expectedActions = [
+      {
+        type: 'LOGIN_SUCCESS',
+        payload: data,
+      },
+    ];
+    
+    return store.dispatch(actions.loginAction(userdata)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});

--- a/src/tests/LoginReducer.test.js
+++ b/src/tests/LoginReducer.test.js
@@ -1,0 +1,55 @@
+import loginReducer from '../reducers/loginReducer';
+import * as types from '../actions/types';
+ 
+const initialState = {
+  message: '',
+  user: {},
+  status: 'none',
+};
+ 
+const responsedata_success = {
+  user: {
+    email: 'testuser@email.com',
+    username: 'testuser',
+    token: 'user-token',
+  },
+};
+ 
+const responsedata_failure = {
+  errors: {
+    error: ['A user with this email and password was not found.'],
+  },
+};
+ 
+ 
+describe('Login reducer', () => {
+  it('should return the initial state', () => {
+    expect(loginReducer(initialState, {})).toEqual(initialState);
+  });
+ 
+  it('should handle LOGIN_SUCCESS', () => {
+    expect(loginReducer(initialState, {
+      type: types.LOGIN_SUCCESS,
+      payload: responsedata_success,
+    })).toEqual(
+      {
+        message: responsedata_success,
+        status: 'loading',
+        user: {},
+      },
+    );
+  });
+ 
+  it('should handle LOGIN_FAILURE', () => {
+    expect(loginReducer(initialState, {
+      type: types.LOGIN_FAILURE,
+      payload: responsedata_failure,
+    })).toEqual(
+      {
+        message: responsedata_failure.errors,
+        status: 'error',
+        user: {},
+      },
+    );
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Returns descriptive messages to users
#### Description of Task to be completed?
Adds popup responses to: 
- User login
- Like/Dislike an article
#### How should this be manually tested?
After pulling this branch locally:
- run `yarn start` to run the application in your browser
- Login to Author's Haven and click on the Author's Haven logo in the Navigation Bar 
- Select an article
- 'Like' or 'Dislike' the article and note the UI's response
#### Any background context you want to provide?
Some features had descriptive popups incorporated in them whereas others didn't. This needed to be remedied to keep the application neat and consistent.
#### What are the relevant pivotal tracker stories?
[#162164332](https://www.pivotaltracker.com/story/show/162164332)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/40589388/48932460-11f9d880-ef0d-11e8-9c75-8e42568c7f5d.png)
![image](https://user-images.githubusercontent.com/40589388/48932485-3fdf1d00-ef0d-11e8-97f6-805434e7e8bf.png)
